### PR TITLE
make clean no longer errors if files are missing

### DIFF
--- a/Program/Makefile
+++ b/Program/Makefile
@@ -37,5 +37,5 @@ clean :
 ifeq ($(OS), Windows_NT)
 	del $(EXECUTABLE) $(OBJECTS)
 else
-	rm $(EXECUTABLE) $(OBJECTS)
+	rm -f $(EXECUTABLE) $(OBJECTS)
 endif


### PR DESCRIPTION
a very minor thing, but it was annoying me when making a buildscript for my project, so I figured maybe it annoyed someone else.